### PR TITLE
Add `binary()` and modify `C()`

### DIFF
--- a/formulae/terms/call.py
+++ b/formulae/terms/call.py
@@ -156,11 +156,12 @@ class Call:
             evaluation, and the latter is equal to ``"numeric"``.
         """
         if isinstance(x, np.ndarray):
-            value = np.atleast_2d(x)
-            if x.shape[0] == 1 and x.shape[1] > 1:
-                value = value.T
+            value = x.flatten()
+            if value.ndim > 1:
+                raise ValueError(f"The result of {self.name} is not 1-dimensional.")
+            value = value[:, np.newaxis]
         elif isinstance(x, pd.Series):
-            value = np.atleast_2d(x.to_numpy()).T
+            value = x.to_numpy()[:, np.newaxis]
         else:
             raise ValueError(f"Call result is of an unrecognized type ({type(x)}).")
         return {"value": value, "type": "numeric"}

--- a/formulae/tests/test_design_matrices.py
+++ b/formulae/tests/test_design_matrices.py
@@ -626,6 +626,10 @@ def test_binary_function():
     term = design_matrices("y ~ binary(x, z)", data).common["binary(x, z)"].squeeze()
     assert np.array_equal(np.where(term == 1), np.where(data["x"] == z))
 
+    # Pass nothing
+    term = design_matrices("y ~ binary(x)", data).common["binary(x)"].squeeze()
+    assert np.array_equal(np.where(term == 1), np.where(data["x"] == 5))
+
     # Values not found in the variable
     with pytest.raises(ValueError):
         design_matrices("y ~ binary(g, 'Not found')", data)

--- a/formulae/tests/test_design_matrices.py
+++ b/formulae/tests/test_design_matrices.py
@@ -402,12 +402,6 @@ def test_built_in_transforms(data):
         "C(x3)[4]",
     ]
 
-    # Specify reference -> it is converted into 0-1 variable
-    dm = design_matrices("y ~ C(x3, 3)", data)
-    assert dm.common.terms_info["C(x3, 3)"]["type"] == "numeric"
-    assert dm.common.terms_info["C(x3, 3)"]["full_names"] == ["C(x3, 3)"]
-    assert all(dm.common["C(x3, 3)"][:, 0] == np.where(data["x3"] == 3, 1, 0))
-
     # Specify levels, different to observed
     lvls = [3, 2, 4, 1]
     dm = design_matrices("y ~ C(x3, levels=lvls)", data)
@@ -601,3 +595,86 @@ def test_categoric_responses():
     assert response.binary is True
     assert response.baseline is None
     assert response.success == "B"
+
+
+def test_binary_function():
+    size = 100
+    data = pd.DataFrame(
+        {
+            "y": np.random.randint(0, 5, size=size),
+            "x": np.random.randint(5, 10, size=size),
+            "g": np.random.choice(["a", "b", "c"], size=size),
+        }
+    )
+
+    # String value
+    term = design_matrices("y ~ binary(g, 'c')", data).common["binary(g, c)"].squeeze()
+    assert np.array_equal(np.where(term == 1), np.where(data["g"] == "c"))
+
+    # Numeric value
+    term = design_matrices("y ~ binary(x, 7)", data).common["binary(x, 7)"].squeeze()
+    assert np.array_equal(np.where(term == 1), np.where(data["x"] == 7))
+
+    # Variable name
+    # string
+    m = "b"
+    term = design_matrices("y ~ binary(g, m)", data).common["binary(g, m)"].squeeze()
+    assert np.array_equal(np.where(term == 1), np.where(data["g"] == m))
+
+    # numeric
+    z = 8
+    term = design_matrices("y ~ binary(x, z)", data).common["binary(x, z)"].squeeze()
+    assert np.array_equal(np.where(term == 1), np.where(data["x"] == z))
+
+    # Values not found in the variable
+    with pytest.raises(ValueError):
+        design_matrices("y ~ binary(g, 'Not found')", data)
+
+    with pytest.raises(ValueError):
+        design_matrices("y ~ binary(x, 999)", data)
+
+
+def test_C_function():
+    size = 100
+    data = pd.DataFrame(
+        {
+            "y": np.random.randint(0, 5, size=size),
+            "x": np.random.randint(5, 10, size=size),
+            "g": np.random.choice(["a", "b", "c"], size=size),
+        }
+    )
+
+    term = design_matrices("y ~ C(x)", data).common.terms_info["C(x)"]
+    assert term["type"] == "categoric"
+    assert term["levels"] == [5, 6, 7, 8, 9]
+    assert term["reference"] == 5
+
+    term = design_matrices("y ~ C(x, 7)", data).common.terms_info["C(x, 7)"]
+    assert term["type"] == "categoric"
+    assert term["levels"] == [7, 5, 6, 8, 9]
+    assert term["reference"] == 7
+
+    l = [6, 8, 5, 7, 9]
+    term = design_matrices("y ~ C(x, levels=l)", data).common.terms_info["C(x, levels = l)"]
+    assert term["type"] == "categoric"
+    assert term["levels"] == l
+    assert term["reference"] == 6
+
+    term = design_matrices("y ~ C(g)", data).common.terms_info["C(g)"]
+    assert term["type"] == "categoric"
+    assert term["levels"] == ["a", "b", "c"]
+    assert term["reference"] == "a"
+
+    term = design_matrices("y ~ C(g, 'c')", data).common.terms_info["C(g, c)"]
+    assert term["type"] == "categoric"
+    assert term["levels"] == ["c", "a", "b"]
+    assert term["reference"] == "c"
+
+    l = ["b", "c", "a"]
+    term = design_matrices("y ~ C(g, levels=l)", data).common.terms_info["C(g, levels = l)"]
+    assert term["type"] == "categoric"
+    assert term["levels"] == l
+    assert term["reference"] == "b"
+
+    with pytest.raises(ValueError):
+        design_matrices("y ~ C(g, 'c', levels=l)", data)


### PR DESCRIPTION
This PR adds a new function `binary()` and modifies how `C()` works. Copying and pasting an illustration from https://github.com/bambinos/bambi/issues/380


The solution I propose consists of having two helper functions `binary()` and `C()`. The first is invoked when you want to derive a 0-1 variable from another variable. The second is invoked when you want to convert one variable into categorical or manipulate their levels. Some examples

* `binary(variable, success)`

```python
# x is character with levels 'a', 'b', 'c'. 
# The level 'b' is converted to 1, everything else is 0.
design_matrices("y ~ binary(x, 'b')")

# x is numeric with values 1, 2, 3, 4, 5. 
# The value 5 is converted to 1, everything else is 0.
design_matrices("y ~ binary(x, 5)")
```
You could also use `binary(x)` and formulae will pick the value taken as success (encoded with a 1)

* `C(variable, reference, levels)`

```python
# x is character with levels 'a', 'b', 'c'.  
# The level 'c' is taken as baseline, all the rest mantain same order. 
# Resuling order 'c', 'a', 'b'
design_matrices("y ~ C(x, 'a')")

# x is numeric with values 1, 2, 3, 4, 5.  
# The value 5 is taken as baseline, all the rest mantain the same order.
# Resuling order 5, 1, 2, 3, 4
design_matrices("y ~ binary(x, 5)")

# x is character with values 'low', 'medium', 'high'.
# By default, the order is  'high', 'low', 'medium', but we want to keep  'low', 'medium', 'high'.
l = ['low', 'medium', 'high']
design_matrices("y ~ C(x, levels=l)")

# x is numeric with values 1, 2, 3.
# By default, the order is 1, 2, 3. But we want 3, 2, 1
l = [3, 2, 1]
design_matrices("y ~ C(x, levels=l)")
```

If you want to convert a variable to categorical without specifying order (which means you'll get default order) you can do `C(variable)`.

---

Last but not least, you could also pass a variable name instead of the value. For example

```python
ref = "This is a long variable name I don't want to type in my formula"
design_matrices("y ~ C(x, ref)")
design_matrices("y ~ binary(x, ref)")
```