### PR TITLE
Improve how we handle `prop()` and `offset()`

### DIFF
--- a/formulae/matrices.py
+++ b/formulae/matrices.py
@@ -124,6 +124,11 @@ class ResponseVector:
             else:
                 self.baseline = self.term.term.metadata["reference"]
 
+    def _evaluate_new_data(self, data):
+        if self.type == "proportion":
+            return self.term.term.eval_new_data(data)
+        raise ValueError("Can't evaluate response term with type different to 'proportion'")
+
     def as_dataframe(self):
         """Returns ``self.design_vector`` as a pandas.DataFrame."""
         data = pd.DataFrame(self.design_vector)


### PR DESCRIPTION
This PR enables the evaluation of `prop()` and `offset()` terms on new data. These types of terms are very peculiar, and they don't obey the same evaluation rules than the other terms.

* `prop()`
  + Remember this function can only be used for response terms. Its evaluation is produced to obtain the values for the 'trials' part of the term. In combination with a posterior for the probability of success, this can be used to estimate the number of successes.
  + If `prop(var1, var2)`, the new data frame must have values for `var2`, and these are returned.
  + If `prop(var1, constant)` the term returns an array with its length taken from the length of the new data frame and with all the values equal to `constant`.
* `offset()`
  + If `offset(var1)`, the new data frame must have values for `var1`, and these are returned.
  + If `offset(constant)`, it returns an array with its length taken from the length of the new data frame and with all the values equal to `constant`.

In addition, with this PR it is now possible to use `prop()` and `proportion()` indistinctively just in case someone likes a more explicit approach.