### PR TITLE
Add basis spline stateful transformation

### DIFF
--- a/formulae/matrices.py
+++ b/formulae/matrices.py
@@ -213,7 +213,7 @@ class CommonEffectsMatrix:
         self.data = data
         self.eval_env = eval_env
         d = self.model.eval(self.data, self.eval_env)
-        self.design_matrix = np.column_stack([d[key] for key in d.keys()])
+        self.design_matrix = np.hstack([d[key] for key in d.keys()])
         self.terms_info = {}
         # Get types and column slices
         start = 0

--- a/formulae/parser.py
+++ b/formulae/parser.py
@@ -1,6 +1,5 @@
 # inconsistently raises this problem
 # pylint: disable=relative-beyond-top-level
-from numpy.lib.arraysetops import isin
 from .expr import Assign, Grouping, Binary, Unary, Call, Variable, QuotedName, Literal
 from .token import Token
 from .utils import listify

--- a/formulae/terms/call.py
+++ b/formulae/terms/call.py
@@ -161,10 +161,10 @@ class Call:
             evaluation, and the latter is equal to ``"numeric"``.
         """
         if isinstance(x, np.ndarray):
-            value = x.flatten()
-            if value.ndim > 1:
-                raise ValueError(f"The result of {self.name} is not 1-dimensional.")
-            value = value[:, np.newaxis]
+            if x.ndim == 1:
+                value = x[:, np.newaxis]
+            else:
+                value = x
         elif isinstance(x, pd.Series):
             value = x.to_numpy()[:, np.newaxis]
         else:

--- a/formulae/tests/test_spline.py
+++ b/formulae/tests/test_spline.py
@@ -1,0 +1,318 @@
+import pytest
+import re
+
+import numpy as np
+import pandas as pd
+
+from formulae.matrices import design_matrices
+from formulae.transforms import BSpline
+
+
+@pytest.fixture(scope="module")
+def data():
+    rng = np.random.default_rng(1234)
+    size = 21
+    data = pd.DataFrame(
+        {"seq": np.linspace(0, 1, 21), "x1": rng.uniform(size=size), "x2": rng.uniform(size=size)}
+    )
+    return data
+
+
+@pytest.fixture(scope="module")
+def sequence():
+    return np.linspace(0, 1, 21)
+
+
+def test_basic(sequence):
+    bs = BSpline()
+    matrix = bs(sequence, 3)
+
+    assert np.allclose(
+        matrix[:, 0],
+        [
+            0.000000,
+            0.135375,
+            0.243000,
+            0.325125,
+            0.384000,
+            0.421875,
+            0.441000,
+            0.443625,
+            0.432000,
+            0.408375,
+            0.375000,
+            0.334125,
+            0.288000,
+            0.238875,
+            0.189000,
+            0.140625,
+            0.096000,
+            0.057375,
+            0.027000,
+            0.007125,
+            0.000000,
+        ],
+    )
+
+    assert np.allclose(
+        matrix[:, 1],
+        [
+            0.000000,
+            0.007125,
+            0.027000,
+            0.057375,
+            0.096000,
+            0.140625,
+            0.189000,
+            0.238875,
+            0.288000,
+            0.334125,
+            0.375000,
+            0.408375,
+            0.432000,
+            0.443625,
+            0.441000,
+            0.421875,
+            0.384000,
+            0.325125,
+            0.243000,
+            0.135375,
+            0.000000,
+        ],
+    )
+
+    assert np.allclose(
+        matrix[:, 2],
+        [
+            0.000000,
+            0.000125,
+            0.001000,
+            0.003375,
+            0.008000,
+            0.015625,
+            0.027000,
+            0.042875,
+            0.064000,
+            0.091125,
+            0.125000,
+            0.166375,
+            0.216000,
+            0.274625,
+            0.343000,
+            0.421875,
+            0.512000,
+            0.614125,
+            0.729000,
+            0.857375,
+            1.000000,
+        ],
+    )
+
+
+def test_degree(sequence):
+    bs = BSpline()
+    matrix = bs(sequence, df=1, degree=1)
+    true = np.array(
+        [
+            [
+                0.0,
+                0.05,
+                0.1,
+                0.15,
+                0.2,
+                0.25,
+                0.3,
+                0.35,
+                0.4,
+                0.45,
+                0.5,
+                0.55,
+                0.6,
+                0.65,
+                0.7,
+                0.75,
+                0.8,
+                0.85,
+                0.9,
+                0.95,
+                1.0,
+            ]
+        ]
+    )
+    assert np.allclose(matrix, true.T)
+
+
+def test_basic_through_design_matrices(data):
+    matrix = design_matrices("bs(seq, 3) - 1", data).common.design_matrix
+    true = np.array(
+        [
+            [
+                0.000000,
+                0.135375,
+                0.243000,
+                0.325125,
+                0.384000,
+                0.421875,
+                0.441000,
+                0.443625,
+                0.432000,
+                0.408375,
+                0.375000,
+                0.334125,
+                0.288000,
+                0.238875,
+                0.189000,
+                0.140625,
+                0.096000,
+                0.057375,
+                0.027000,
+                0.007125,
+                0.000000,
+            ],
+            [
+                0.000000,
+                0.007125,
+                0.027000,
+                0.057375,
+                0.096000,
+                0.140625,
+                0.189000,
+                0.238875,
+                0.288000,
+                0.334125,
+                0.375000,
+                0.408375,
+                0.432000,
+                0.443625,
+                0.441000,
+                0.421875,
+                0.384000,
+                0.325125,
+                0.243000,
+                0.135375,
+                0.000000,
+            ],
+            [
+                0.000000,
+                0.000125,
+                0.001000,
+                0.003375,
+                0.008000,
+                0.015625,
+                0.027000,
+                0.042875,
+                0.064000,
+                0.091125,
+                0.125000,
+                0.166375,
+                0.216000,
+                0.274625,
+                0.343000,
+                0.421875,
+                0.512000,
+                0.614125,
+                0.729000,
+                0.857375,
+                1.000000,
+            ],
+        ]
+    )
+
+    assert np.allclose(matrix, true.T)
+
+
+def test_intercept(sequence):
+    bs = BSpline()
+    matrix = bs(sequence, 2, degree=1, intercept=True)
+    true = np.array(
+        [
+            [1.0, 0.0],
+            [0.95, 0.05],
+            [0.9, 0.1],
+            [0.85, 0.15],
+            [0.8, 0.2],
+            [0.75, 0.25],
+            [0.7, 0.3],
+            [0.65, 0.35],
+            [0.6, 0.4],
+            [0.55, 0.45],
+            [0.5, 0.5],
+            [0.45, 0.55],
+            [0.4, 0.6],
+            [0.35, 0.65],
+            [0.3, 0.7],
+            [0.25, 0.75],
+            [0.2, 0.8],
+            [0.15, 0.85],
+            [0.1, 0.9],
+            [0.05, 0.95],
+            [0.0, 1.0],
+        ]
+    )
+    assert np.allclose(matrix, true)
+
+
+def test_invalid_degree(sequence):
+    with pytest.raises(ValueError, match="'degree' must be an integer, not"):
+        bs = BSpline()
+        bs(sequence, degree=0.3)
+
+    with pytest.raises(ValueError, match="'degree' must be greater than 0, not"):
+        bs = BSpline()
+        bs(sequence, degree=-1)
+
+
+def test_df_and_knots_are_none(sequence):
+    with pytest.raises(ValueError, match="Must specify either 'df' or 'knots'"):
+        bs = BSpline()
+        bs(sequence)
+
+
+def test_invalid_df(sequence):
+    with pytest.raises(ValueError, match="'df' must be either None or integer"):
+        bs = BSpline()
+        bs(sequence, df=[2])
+
+
+def test_df_too_small_for_degree(sequence):
+    with pytest.raises(
+        ValueError, match="df=2 is too small for degree=3 and intercept=False; it must be >= 3"
+    ):
+        bs = BSpline()
+        bs(sequence, df=2, degree=3)
+
+    with pytest.raises(
+        ValueError, match="df=2 is too small for degree=2 and intercept=True; it must be >= 3"
+    ):
+        bs = BSpline()
+        bs(sequence, df=2, degree=2, intercept=True)
+
+
+def test_provided_bad_number_of_knots(sequence):
+    with pytest.raises(ValueError, match="df=5 with degree=3 implies 2 knots; but 3 were provided"):
+        bs = BSpline()
+        bs(sequence, df=5, degree=3, knots=[0.5, 0.6, 0.7])
+
+    with pytest.raises(ValueError, match="df=5 with degree=3 implies 2 knots; but 1 were provided"):
+        bs = BSpline()
+        bs(sequence, df=5, degree=3, knots=[0.5])
+
+
+def test_provided_bad_dimension_of_knots(sequence):
+    with pytest.raises(ValueError, match="'knots' must be 1 dimensional"):
+        bs = BSpline()
+        bs(sequence, df=5, degree=3, knots=np.array([[0.5], [0.6]]))
+
+
+def test_knots_dont_cover_range(sequence):
+    with pytest.raises(
+        ValueError, match=re.escape("Some knot values [1.2] fall above upper bound 1.0")
+    ):
+        bs = BSpline()
+        bs(sequence, df=5, degree=3, knots=[0.3, 1.2])
+
+    with pytest.raises(
+        ValueError, match=re.escape("Some knot values [-0.1] fall below lower bound 0")
+    ):
+        bs = BSpline()
+        bs(sequence, df=5, degree=3, knots=[-0.1, 0.3])

--- a/formulae/tests/test_terms_call.py
+++ b/formulae/tests/test_terms_call.py
@@ -53,6 +53,7 @@ def test_call_set_data_errors():
         x.set_data(True)
 
 
+@pytest.mark.skip(reason="I doubt it's possible the call object has to evaluates a row vector")
 def test_call_eval_numeric():
     f = lambda x: x
     x = call("f(x)")

--- a/formulae/transforms.py
+++ b/formulae/transforms.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 
 from pandas.api.types import is_numeric_dtype
+from scipy.interpolate import splev
 
 # Stateful transformations.
 # These transformations have memory about the state of parameters that are
@@ -222,6 +223,139 @@ def offset(x):
     return Offset(x)
 
 
+class BSpline:
+    """B-Spline representation
+
+    Generates a B-spline basis for ``x``, allowing non-linear fits. The usual
+    usage is something like::
+
+        y ~ 1 + bs(x, 4)
+
+    to fit ``y`` as a smooth function of ``x``, with 4 degrees of freedom
+    given to the smooth.
+
+    Parameters
+    ----------
+    x: 1D array-like
+        The data.
+    df: The number of degrees of freedom to use for this spline. The return value will have this
+        many columns. You must specify at least one of ``df`` and ``knots``.
+    knots: 1D array-like or None
+        The interior knots to use for the spline. If unspecified, then equally spaced quantiles of
+        the input data are used. You must specify at least one of ``df`` and ``knots`
+    degree: int
+        Degree of the piecewise polynomial. Default is 3 for cubic splines.
+    intercept: bool
+        If ``True``, an intercept is included in the basis. Default is ``False``.
+    lower_bound:
+        The lower exterior knot location.
+    upper_bound:
+        The upper exterior knot location.
+    """
+
+    def __init__(self):
+        self.params_set = False
+        self._intercept = None
+        self._degree = None
+        self._knots = None
+
+    def __call__(
+        self, x, df=None, knots=None, degree=3, intercept=False, lower_bound=None, upper_bound=None
+    ):
+        if not self.params_set:
+            self._initialize(x, df, knots, degree, intercept, lower_bound, upper_bound)
+        return self.eval(x)
+
+    def _initialize(self, x, df, knots, degree, intercept, lower_bound, upper_bound):
+
+        if not isinstance(degree, int):
+            raise ValueError(f"'degree' must be an integer, not {type(degree)}")
+
+        if degree < 0:
+            raise ValueError(f"'degree' must be greater than 0, not {degree}")
+
+        if df is None and knots is None:
+            raise ValueError("Must specify either 'df' or 'knots'")
+
+        if df and not isinstance(df, int):
+            raise ValueError("'df' must be either None or integer")
+        # XTODO: Check the type of knots.
+
+        order = degree + 1
+
+        if df:
+            n_inner_knots = df - order
+            if not intercept:
+                n_inner_knots += 1
+            if n_inner_knots < 0:
+                # We know that n_inner_knots is negative;
+                # If df were that much larger, it would have been zero, and things would work.
+                raise ValueError(
+                    f"df={df} is too small for degree={degree} and intercept={intercept}; "
+                    f"it must be >= {df - n_inner_knots}"
+                )
+
+            # User specified 'df' AND 'knots'
+            if knots:
+                if len(knots) != n_inner_knots:
+                    raise ValueError(
+                        f"df={df} with degree={degree} implies {n_inner_knots} knots; "
+                        f"but {len(knots)} were provided"
+                    )
+            # User specified 'df' but NOT 'knots'
+            else:
+                knot_quantiles = np.linspace(0, 1, n_inner_knots + 2)[1:-1]
+                inner_knots = np.percentile(x, 100 * np.asarray(knot_quantiles))
+
+        if knots:
+            inner_knots = knots
+
+        if lower_bound is None:
+            lower_bound = np.min(x)
+
+        if upper_bound is None:
+            upper_bound = np.max(x)
+
+        if lower_bound > upper_bound:
+            raise ValueError(f"'lower_bound' > 'upper_bound' ({lower_bound} > {upper_bound})")
+
+        inner_knots = np.asarray(inner_knots)
+        if inner_knots.ndim > 1:
+            raise ValueError("Knots must be 1 dimensional")
+
+        if np.any(inner_knots < lower_bound):
+            raise ValueError(
+                f"Some knot values {inner_knots[inner_knots < lower_bound]} "
+                f"fall below lower bound {lower_bound}"
+            )
+
+        if np.any(inner_knots > upper_bound):
+            raise ValueError(
+                f"Some knot values {inner_knots[inner_knots > upper_bound]} "
+                f"fall above upper bound {upper_bound}"
+            )
+
+        all_knots = np.concatenate(([lower_bound, upper_bound] * order, inner_knots))
+        all_knots.sort()
+
+        self._intercept = intercept
+        self._degree = degree
+        self._knots = all_knots
+        self.params_set = True
+
+    def eval(self, x):
+        n_bases = len(self._knots) - (self._degree + 1)
+        basis = np.empty((x.shape[0], n_bases), dtype=float)
+        for i in range(n_bases):
+            coefs = np.zeros((n_bases,))
+            coefs[i] = 1
+            basis[:, i] = splev(x, (self._knots, coefs, self._degree))
+
+        if not self._intercept:
+            basis = basis[:, 1:]
+        return basis
+
+
 TRANSFORMS = {
     "I": I,
     "C": C,
@@ -231,4 +365,4 @@ TRANSFORMS = {
     "proportion": proportion,
     "offset": offset,
 }
-STATEFUL_TRANSFORMS = {"center": Center, "scale": Scale, "standardize": Scale}
+STATEFUL_TRANSFORMS = {"center": Center, "scale": Scale, "standardize": Scale, "bs": BSpline}

--- a/formulae/transforms.py
+++ b/formulae/transforms.py
@@ -283,7 +283,7 @@ class BSpline:
 
         order = degree + 1
 
-        if df:
+        if df is not None:
             n_inner_knots = df - order
             if not intercept:
                 n_inner_knots += 1
@@ -296,7 +296,7 @@ class BSpline:
                 )
 
             # User specified 'df' AND 'knots'
-            if knots:
+            if knots is not None:
                 if len(knots) != n_inner_knots:
                     raise ValueError(
                         f"df={df} with degree={degree} implies {n_inner_knots} knots; "
@@ -307,7 +307,7 @@ class BSpline:
                 knot_quantiles = np.linspace(0, 1, n_inner_knots + 2)[1:-1]
                 inner_knots = np.percentile(x, 100 * np.asarray(knot_quantiles))
 
-        if knots:
+        if knots is not None:
             inner_knots = knots
 
         if lower_bound is None:
@@ -321,7 +321,7 @@ class BSpline:
 
         inner_knots = np.asarray(inner_knots)
         if inner_knots.ndim > 1:
-            raise ValueError("Knots must be 1 dimensional")
+            raise ValueError("'knots' must be 1 dimensional")
 
         if np.any(inner_knots < lower_bound):
             raise ValueError(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,6 @@ astroid>=2.5.2
 pytest>=6.2.2
 pytest-cov>=2.6.1
 black>=20.8b1
-sphinx>=1.8
+sphinx>=4.1.1
 nbsphinx>=0.4.2
 pydata-sphinx-theme>=0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy>=1.16.1
+numpy>=1.16
 pandas>=1.0.0
 scipy>=1.5.4


### PR DESCRIPTION
Adds an equivalent of the `bs()` function in the `splines` package in `R`. This is a stateful transformation by the way (it remember knots, bounds, and whether it has intercept or not).


Using the `engine` dataset from the `R` package `gamair`, we have:

```python
import pandas as pd
from formulae import  design_matrices

data = pd.DataFrame({
    "size": [
        2.78, 2.43, 2.32, 2.43, 2.98, 2.32, 2.32, 2.32, 2.32, 2.13, 
        2.13, 2.13, 2.98, 1.99, 1.99, 1.99, 1.78, 1.58, 1.42
    ],
    "wear": [
        3, 3.1, 4.8, 3.3, 2.8, 2.9, 3.8, 3, 2.7, 3.2, 2.4, 2.6, 1.7,
        2.6, 2.8, 2.4, 2.5, 4.2, 4
    ]
})
design_matrices("wear ~ bs(size, 4)", data).common.design_matrix
```

```
array([[1.        , 0.00498077, 0.09481583, 0.56163869, 0.33856471],
       [1.        , 0.10358454, 0.429405  , 0.46238083, 0.00462963],
       [1.        , 0.17899408, 0.48816568, 0.33284024, 0.        ],
       [1.        , 0.10358454, 0.429405  , 0.46238083, 0.00462963],
       [1.        , 0.        , 0.        , 0.        , 1.        ],
       [1.        , 0.17899408, 0.48816568, 0.33284024, 0.        ],
       [1.        , 0.17899408, 0.48816568, 0.33284024, 0.        ],
       [1.        , 0.17899408, 0.48816568, 0.33284024, 0.        ],
       [1.        , 0.17899408, 0.48816568, 0.33284024, 0.        ],
       [1.        , 0.36011331, 0.46706614, 0.16341177, 0.        ],
       [1.        , 0.36011331, 0.46706614, 0.16341177, 0.        ],
       [1.        , 0.36011331, 0.46706614, 0.16341177, 0.        ],
       [1.        , 0.        , 0.        , 0.        , 1.        ],
       [1.        , 0.48758651, 0.37856345, 0.08455375, 0.        ],
       [1.        , 0.48758651, 0.37856345, 0.08455375, 0.        ],
       [1.        , 0.48758651, 0.37856345, 0.08455375, 0.        ],
       [1.        , 0.56530178, 0.19739645, 0.02130178, 0.        ],
       [1.        , 0.39454797, 0.04771909, 0.00187011, 0.        ],
       [1.        , 0.        , 0.        , 0.        , 0.        ]])
```

**EDIT**

By mistake, I ended up including here commits related to other topics. Now, it is also possible to pass response levels with index notation without having to use an explicit string. This doesn't work when the level contains spaces (must use a string there) or when the level is a number (use binary() function there). Examples:

This works:
* `"y['A'] ~ x1 + x2"`
* `"y[A] ~ x1 + x2"`
* `"y['My level contains spaces'] ~ x1 + x2"`
* `"binary(y, 2)" ~ x1 + x2"`


This does **not** work
* `"y[My level contains spaces] ~ x1 + x2"`
* `"y[1] ~ x1 + x2"`
