### PR TITLE
Adding support for survival functions #79

### DIFF
--- a/formulae/terms/call.py
+++ b/formulae/terms/call.py
@@ -6,7 +6,7 @@ import pandas as pd
 from pandas.api.types import is_categorical_dtype, is_numeric_dtype, is_string_dtype
 
 from formulae.categorical import ENCODINGS, CategoricalBox, Treatment
-from formulae.transforms import TRANSFORMS, Proportion, Offset
+from formulae.transforms import TRANSFORMS, Proportion, Offset, Surv
 from formulae.terms.call_utils import CallVarsExtractor
 
 
@@ -110,6 +110,8 @@ class Call:
             x.set_size(len(data_mask.index))
         elif isinstance(x, Proportion):
             self.kind = "proportion"
+        elif isinstance(x, Surv):
+            self.kind = "surv"
         else:
             raise ValueError(f"Call result is of an unrecognized type ({type(x)}).")
         self._intermediate_data = x
@@ -143,6 +145,8 @@ class Call:
                 self.eval_offset(self._intermediate_data)
             elif self.kind == "proportion":
                 self.eval_proportion(self._intermediate_data)
+            elif self.kind == "surv":
+                self.eval_surv(self._intermediate_data)
             else:
                 raise ValueError(f"Call result is of an unrecognized type ({self.kind}).")
         except:
@@ -243,6 +247,11 @@ class Call:
         if not self.is_response:
             raise ValueError("'proportion()' can only be used as a response term.")
         self.value = proportion.eval()
+
+    def eval_surv(self, surv):
+        if not self.is_response:
+            raise ValueError("'surv()' can only be used as a response term.")
+        self.value = surv.eval()
 
     def eval_offset(self, offset):
         if self.is_response:

--- a/formulae/terms/terms.py
+++ b/formulae/terms/terms.py
@@ -548,7 +548,7 @@ class Term:
 
         It is like .labels, without the name of the terms
         """
-        if self.kind is None or self.kind in ["numeric", "proportion"]:
+        if self.kind is None or self.kind in ["numeric", "proportion", "surv"]:
             levels = None
         elif self.kind == "interaction":
             levels = []
@@ -771,6 +771,9 @@ class Response:
         if isinstance(term, Term):
             n = len(term.components)
             if n == 1:
+                self.term = term
+                self.term.components[0].is_response = True
+            elif n == 2:
                 self.term = term
                 self.term.components[0].is_response = True
             else:

--- a/formulae/tests/test_transforms.py
+++ b/formulae/tests/test_transforms.py
@@ -1,0 +1,10 @@
+from formulae.transforms import Surv
+
+def test_Surv():
+    assert Surv([10], [0]).eval().shape[0] == 1
+    assert Surv([10], [0]).eval().shape[1] == 2
+    assert Surv([10, 20, 30], [0, 1, 1]).eval().shape[0] == 3
+    assert Surv([10, 20, 30], [0, 1, 1]).eval().shape[1] == 2
+
+    assert Surv([10], [0]).eval()[0][0] == 10
+    assert Surv([10], [0]).eval()[0][1] == 0

--- a/formulae/transforms.py
+++ b/formulae/transforms.py
@@ -400,22 +400,22 @@ class Polynomial:
 class Surv:
     """Transformation for survival functions
 
-        This transformation returns a 2xn array with the time-to-event and censor status
+        This transformation returns a 2xn array with the time-to-event and event status
 
         Parameters
         ----------
         time: 1d array-like
             Time-to-event
-        censor: 1d array-like
-            Censoring status
-            (0=uncensored, 1=right censored)
+        event: 1d array-like
+            Event status
+            (0=right censored, 1=event)
         """
-    def __init__(self, time, censor):
+    def __init__(self, time, event):
         self.time = time
-        self.censor = censor
+        self.event = event
 
     def eval(self):
-        return np.stack((self.time, self.censor)).T
+        return np.stack((self.time, self.event)).T
 
 TRANSFORMS = {
     "B": binary,

--- a/formulae/transforms.py
+++ b/formulae/transforms.py
@@ -396,6 +396,16 @@ class Polynomial:
         P /= np.array([np.sqrt(get_norm(k)) for k in range(0, self.degree + 1)])
         return P[:, 1:]
 
+class Surv:
+    def __init__(self, time, censor):
+        self.time = time
+        self.censor = censor
+
+    # def __call__(self, time, censor):
+    #     return [time, censor]
+
+    def eval(self):
+        return self.time # np.stack((self.time, self.censor)).T
 
 TRANSFORMS = {
     "B": binary,
@@ -408,6 +418,7 @@ TRANSFORMS = {
     "proportion": proportion,
     "S": S,
     "T": T,
+    "Surv": Surv,
 }
 
 STATEFUL_TRANSFORMS = {

--- a/formulae/transforms.py
+++ b/formulae/transforms.py
@@ -396,16 +396,26 @@ class Polynomial:
         P /= np.array([np.sqrt(get_norm(k)) for k in range(0, self.degree + 1)])
         return P[:, 1:]
 
+
 class Surv:
+    """Transformation for survival functions
+
+        This transformation returns a 2xn array with the time-to-event and censor status
+
+        Parameters
+        ----------
+        time: 1d array-like
+            Time-to-event
+        censor: 1d array-like
+            Censoring status
+            (0=uncensored, 1=right censored)
+        """
     def __init__(self, time, censor):
         self.time = time
         self.censor = censor
 
-    # def __call__(self, time, censor):
-    #     return [time, censor]
-
     def eval(self):
-        return self.time # np.stack((self.time, self.censor)).T
+        return np.stack((self.time, self.censor)).T
 
 TRANSFORMS = {
     "B": binary,


### PR DESCRIPTION
This PR adds a transformation for survival type responses. It is similar to R's `Surv`.

`Surv(time, status) ~ ` returns a 2xn matrix with the time and the event status. These can then be used in the model to handle censored and uncensored data differently.

#79 