### PR TITLE
Fix evaluation of new offset terms with call arguments

### DIFF
--- a/formulae/terms/call.py
+++ b/formulae/terms/call.py
@@ -325,7 +325,7 @@ class Call:
             result = np.ones(len(data_mask.index)) * self.call.args[0].value
         else:
             # This works both for LazyVariable (offset(x)) and LazyCall (offset(np.log(x)))
-            offset = self.call.eval(data_mask, self.env) # returns instance of Offset
+            offset = self.call.eval(data_mask, self.env)  # returns instance of Offset
             values = offset.eval()
             if isinstance(values, pd.Series):
                 values = values.to_numpy()

--- a/formulae/terms/call.py
+++ b/formulae/terms/call.py
@@ -324,11 +324,11 @@ class Call:
             # Return value passed as the argument
             result = np.ones(len(data_mask.index)) * self.call.args[0].value
         else:
-            # Extract name of the argument
-            name = self.call.args[0].name
-            values = data_mask[name]
+            # This works both for LazyVariable (offset(x)) and LazyCall (offset(np.log(x)))
+            offset = self.call.eval(data_mask, self.env) # returns instance of Offset
+            values = offset.eval()
             if isinstance(values, pd.Series):
-                values = values.values
+                values = values.to_numpy()
             result = values
         return result
 

--- a/formulae/tests/test_design_matrices.py
+++ b/formulae/tests/test_design_matrices.py
@@ -822,7 +822,7 @@ def test_offset():
     term = dm.common.terms["offset(x)"]
     assert term.kind == "offset"
     assert term.labels == ["offset(x)"]
-    assert (dm.common["offset(x)"].flatten() == data["x"].values).all()
+    assert np.allclose(dm.common["offset(x)"].flatten(), data["x"])
 
     with pytest.raises(
         ValueError, match=re.escape("offset() can only be used with numeric variables")
@@ -831,6 +831,17 @@ def test_offset():
 
     with pytest.raises(ValueError, match=re.escape("offset() cannot be used as a response term.")):
         design_matrices("offset(y) ~ x", data)
+
+    # Creation of new design matrices using calls as arguments work
+    dm = design_matrices("y ~ offset(np.log(x))", data)
+    term = dm.common.terms["offset(np.log(x))"]
+    assert term.kind == "offset"
+    assert term.labels == ["offset(np.log(x))"]
+    assert np.allclose(dm.common["offset(np.log(x))"].flatten(), np.log(data["x"]))
+
+    new_data = pd.DataFrame({"x": [3, 4, 5]})
+    new_common = dm.common.evaluate_new_data(new_data)
+    assert np.allclose(new_common["offset(np.log(x))"].flatten(), np.log(new_data["x"]))
 
 
 def test_predict_prop(beetle):


### PR DESCRIPTION
See https://github.com/bambinos/bambi/issues/571 in Bambi. The creation of new design matrices would fail when an offset term contained a function call as an argument as in `offset(np.log(x))`. 

Now it's fixed.