### PR TITLE
Respect original string in calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Maintenance and fixes
 
 - Multiple calls with unnamed attributes resulted in errors due to trying to hash unhashable types (#88)
+- Term names with call components now use the proper lexeme when one argument is a string (#89)
 
 ### Documentation
 

--- a/formulae/expr.py
+++ b/formulae/expr.py
@@ -165,19 +165,23 @@ class QuotedName:
 
 
 class Literal:
-    def __init__(self, value):
+    def __init__(self, value, lexeme=None):
         self.value = value
+        self.lexeme = lexeme
 
     def __eq__(self, other):
         if not isinstance(other, type(self)):
             return False
-        return self.value == other.value
+        return self.value == other.value and self.lexeme == other.lexeme
 
     def __repr__(self):  # pragma: no cover
         return self.__str__()
 
     def __str__(self):  # pragma: no cover
-        return "Literal(" + str(self.value) + ")"
+        kwargs = {"value": self.value, "lexeme": self.lexeme}
+        body_list = [f"{k}={v}" for k, v in kwargs.items() if v is not None]
+        body = ", ".join(body_list)
+        return f"Literal({body})"
 
     def accept(self, visitor):
         return visitor.visitLiteralExpr(self)

--- a/formulae/parser.py
+++ b/formulae/parser.py
@@ -191,7 +191,8 @@ class Parser:  # pylint: disable=too-many-public-methods
         elif self.match("NUMBER"):
             return Literal(self.previous().literal)
         elif self.match("STRING"):
-            return Literal(self.previous().literal)
+            token = self.previous()
+            return Literal(token.literal, lexeme=token.lexeme)
         elif self.match("BQNAME"):
             return QuotedName(self.previous())
         elif self.match("LEFT_PAREN"):

--- a/formulae/terms/call_resolver.py
+++ b/formulae/terms/call_resolver.py
@@ -153,19 +153,28 @@ class LazyValue:
     ----------
     value: string or numeric
         The value it holds.
+    lexeme: string
+        The string that generated the value it holds
     """
 
-    def __init__(self, value):
+    def __init__(self, value, lexeme):
         self.value = value
+        self.lexeme = lexeme
 
     def __str__(self):
+        if self.lexeme is not None:
+            return self.lexeme
         return str(self.value)
 
     def __hash__(self):
-        return hash(self.value)
+        return hash(self.value, self.lexeme)
 
     def __eq__(self, other):
-        return isinstance(other, type(self)) and self.value == other.value
+        return (
+            isinstance(other, type(self))
+            and self.value == other.value
+            and self.lexeme == other.lexeme
+        )
 
     def accept(self, visitor):
         return visitor.visitLazyValue(self)
@@ -216,7 +225,7 @@ class LazyCall:
 
     def __str__(self):
         args = [str(arg) for arg in self.args]
-        kwargs = [f"{name} = {str(arg)}" for name, arg in self.kwargs.items()]
+        kwargs = [f"{name}={str(arg)}" for name, arg in self.kwargs.items()]
         return f"{self.callee}({', '.join(args + kwargs)})"
 
     def __hash__(self):
@@ -315,7 +324,7 @@ class CallResolver:
         return LazyVariable(expr.name.lexeme)
 
     def visitLiteralExpr(self, expr):
-        return LazyValue(expr.value)
+        return LazyValue(expr.value, expr.lexeme)
 
     def visitQuotedNameExpr(self, expr):
         return LazyVariable(expr.expression.lexeme[1:-1])

--- a/formulae/tests/test_design_matrices.py
+++ b/formulae/tests/test_design_matrices.py
@@ -1202,7 +1202,7 @@ def test_calls_with_lazy_values():
 
 
 def test_call_names_respect_string_lexeme():
-    # If a call has an argument which is a string literal, it's important to 
+    # If a call has an argument which is a string literal, it's important to
     # respect the original lexeme used to represent the string.
     # If it was written with double-quotes, we use double-quotes in the term nmae
     # Analougs if it was written with single-quotes

--- a/formulae/tests/test_parser.py
+++ b/formulae/tests/test_parser.py
@@ -16,7 +16,7 @@ def parse(x, add_intercept=True):
 
 def test_parse_literal():
     p = parse("'A'")
-    assert p == Binary(Literal(1), Token("PLUS", "+"), Literal("A"))
+    assert p == Binary(Literal(1), Token("PLUS", "+"), Literal("A", "'A'"))
 
     p = parse("1")
     assert p == Binary(Literal(1), Token("PLUS", "+"), Literal(1))


### PR DESCRIPTION
This PR introduces breaking changes since terms with a call component containing string arguments will be represented slightly differently now. It keeps the quotes (with the right kind), which is something that wasn't happening before.

Closes #86. It doesn't respect the original function call completely since it always writes keyworded arguments without spaces around the equal symbol. 