### PR TITLE
Add configuration to formulae

### DIFF
--- a/formulae/__init__.py
+++ b/formulae/__init__.py
@@ -1,10 +1,14 @@
 import logging
 
+from .config import Config
 from .matrices import design_matrices
 from .model_description import model_description
 from .version import __version__
 
+config = Config()
+
 __all__ = [
+    "config",
     "design_matrices",
     "model_description",
     "__version__",

--- a/formulae/config.py
+++ b/formulae/config.py
@@ -1,0 +1,37 @@
+class Config:
+    FIELDS = {"EVAL_NEW_CATEGORIES": ("error", "warning", "silent")}
+
+    def __init__(self, config_dict: dict = None):
+        config_dict = {} if config_dict is None else config_dict
+        for field, choices in Config.FIELDS.items():
+            if field in config_dict:
+                value = config_dict[field]
+            else:
+                value = choices[0]
+            self[field] = value
+
+    def __setitem__(self, key, value):
+        setattr(self, key, value)
+
+    def __setattr__(self, key, value):
+        if key in Config.FIELDS:
+            if value in Config.FIELDS[key]:
+                super().__setattr__(key, value)
+            else:
+                raise ValueError(f"{value} is not a valid value for '{key}'")
+        else:
+            raise KeyError(f"'{key}' is not a valid configuration option")
+
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def __str__(self): # pragma: no cover
+        lines = []
+        for field, choices in Config.FIELDS.items():
+            lines.append(f"{field}: {self[field]} (available: {choices})")
+        header = ["Formulae configuration"]
+        header.append("-" * len(header[0]))
+        return "\n".join(header + lines)
+
+    def __repr__(self): # pragma: no cover
+        return str(self)

--- a/formulae/config.py
+++ b/formulae/config.py
@@ -25,7 +25,7 @@ class Config:
     def __getitem__(self, key):
         return getattr(self, key)
 
-    def __str__(self): # pragma: no cover
+    def __str__(self):  # pragma: no cover
         lines = []
         for field, choices in Config.FIELDS.items():
             lines.append(f"{field}: {self[field]} (available: {choices})")
@@ -33,5 +33,5 @@ class Config:
         header.append("-" * len(header[0]))
         return "\n".join(header + lines)
 
-    def __repr__(self): # pragma: no cover
+    def __repr__(self):  # pragma: no cover
         return str(self)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+import pytest
+
+from formulae.config import Config
+
+
+def test_config():
+    config = Config()
+
+    assert config["EVAL_NEW_CATEGORIES"] == "error"
+    assert config.EVAL_NEW_CATEGORIES == "error"
+
+    with pytest.raises(ValueError, match="anything is not a valid value for 'EVAL_NEW_CATEGORIES'"):
+        config.EVAL_NEW_CATEGORIES = "anything"
+
+    with pytest.raises(KeyError, match="'DOESNT_EXIST' is not a valid configuration option"):
+        config.DOESNT_EXIST = "anything"
+
+
+test_config()


### PR DESCRIPTION
Here I add a `formulae.config` mapping that allows getting and setting some configuration options. For now, it has `EVAL_NEW_CATEGORIES` which will determine what formulae to do when we derive a new design matrix out of an existing design matrix with a dataset that has new groups.