### PR TITLE
Allow evaluations on new data with new categories

### DIFF
--- a/formulae/__init__.py
+++ b/formulae/__init__.py
@@ -1,11 +1,9 @@
 import logging
 
-from .config import Config
+from .config import config
 from .matrices import design_matrices
 from .model_description import model_description
 from .version import __version__
-
-config = Config()
 
 __all__ = [
     "config",

--- a/formulae/config.py
+++ b/formulae/config.py
@@ -1,5 +1,5 @@
 class Config:
-    FIELDS = {"EVAL_NEW_CATEGORIES": ("error", "warning", "silent")}
+    FIELDS = {"EVAL_UNSEEN_CATEGORIES": ("error", "warning", "silent")}
 
     def __init__(self, config_dict: dict = None):
         config_dict = {} if config_dict is None else config_dict
@@ -35,3 +35,6 @@ class Config:
 
     def __repr__(self):  # pragma: no cover
         return str(self)
+
+
+config = Config()

--- a/formulae/terms/call.py
+++ b/formulae/terms/call.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -6,6 +7,7 @@ import pandas as pd
 from pandas.api.types import is_categorical_dtype, is_numeric_dtype, is_string_dtype
 
 from formulae.categorical import ENCODINGS, CategoricalBox, Treatment
+from formulae.config import config
 from formulae.transforms import TRANSFORMS, Proportion, Offset
 from formulae.terms.call_utils import CallVarsExtractor
 
@@ -309,12 +311,32 @@ class Call:
         if not difference:
             idxs = pd.Categorical(x, categories=self.levels).codes
             return self.contrast_matrix.matrix[idxs]
-        else:
+
+        if config["EVAL_UNSEEN_CATEGORIES"] == "error":
             difference = [str(x) for x in difference]
             raise ValueError(
-                f"The levels {', '.join(difference)} in '{self.name}' are not present in "
-                "the original data set."
+                f"The levels ({', '.join(difference)}) in '{self.name}' are not present in the "
+                "original data set."
             )
+        # When there's an unseen category it will first use it as if it was the first category
+        # so we can still index 'contrast_matrix.matrix' but then it will replace all the values
+        # in there with all zeros.
+
+        # pandas uses '-1' for unseen levels
+        idxs_original = pd.Categorical(x, categories=self.levels).codes
+        idxs_modified = np.copy(idxs_original)
+        idxs_modified[idxs_original == -1] = 0
+        contribution = self.contrast_matrix.matrix[idxs_modified]
+        contribution[idxs_original == -1] = 0
+
+        if config["EVAL_UNSEEN_CATEGORIES"] == "warning":
+            difference = [str(x) for x in difference]
+            warnings.warn(
+                f"The levels ({', '.join(difference)}) in '{self.name}' are not present in the "
+                "original data set. It's impossible to select appropriate contrasts for them. "
+                "Setting all the indicator variables to zero."
+            )
+        return contribution
 
     def eval_new_data_categorical_box(self, x):
         return self.eval_new_data_categoric(x.data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,11 +6,13 @@ from formulae.config import Config
 def test_config():
     config = Config()
 
-    assert config["EVAL_NEW_CATEGORIES"] == "error"
-    assert config.EVAL_NEW_CATEGORIES == "error"
+    assert config["EVAL_UNSEEN_CATEGORIES"] == "error"
+    assert config.EVAL_UNSEEN_CATEGORIES == "error"
 
-    with pytest.raises(ValueError, match="anything is not a valid value for 'EVAL_NEW_CATEGORIES'"):
-        config.EVAL_NEW_CATEGORIES = "anything"
+    with pytest.raises(
+        ValueError, match="anything is not a valid value for 'EVAL_UNSEEN_CATEGORIES'"
+    ):
+        config.EVAL_UNSEEN_CATEGORIES = "anything"
 
     with pytest.raises(KeyError, match="'DOESNT_EXIST' is not a valid configuration option"):
         config.DOESNT_EXIST = "anything"


### PR DESCRIPTION
#95 added configuration variables. This renames `EVAL_NEW_CATEGORIES` to `EVAL_UNSEEN_CATEGORIES` and allows users to derive new design matrices out of existing ones when the new data frame contains groups that are not seen in the original data frame. This is only possible when `EVAL_UNSEEN_CATEGORIES` is either `"warning"` or `"silent"`. By default, this is disabled because it should be used by people who know what they are doing.