### PR TITLE
fix typo in __str__

### DIFF
--- a/formulae/matrices.py
+++ b/formulae/matrices.py
@@ -88,7 +88,7 @@ class DesignMatrices:
             + "\n"
             + "\n".join(entries)
             + "\n\n"
-            + "Use .reponse, .common, or .group to access the different members."
+            + "Use .response, .common, or .group to access the different members."
         )
         return msg
 

--- a/formulae/terms/terms.py
+++ b/formulae/terms/terms.py
@@ -1066,7 +1066,7 @@ class Model:
         Returns
         -------
         self: :class:`.Model`
-            The same model object but now with a reponse term.
+            The same model object but now with a response term.
         """
         if isinstance(term, Response):
             self.response = term

--- a/tests/test_design_matrices.py
+++ b/tests/test_design_matrices.py
@@ -922,7 +922,7 @@ def test_design_matrices_repr_and_str(data):
         "Response:                (20,)\n"
         "Common:                (20, 2)\n"
         "Group-specific:        (20, 8)\n\n"
-        "Use .reponse, .common, or .group to access the different members."
+        "Use .response, .common, or .group to access the different members."
     )
 
     assert repr(dm) == text


### PR DESCRIPTION
Small typo changes the .reponse to .response like the noted attribute

Here is the new expected __str__
```python
>>> import formulae as fm
>>> data = pd.DataFrame({"y": [1, 2, 3], "x": [2, 3, 4]})
>>> fm.design_matrices("y ~ x", data)
DesignMatrices

                  (rows, cols)
Response:                 (3,)
Common:                 (3, 2)

Use .response, .common, or .group to access the different members.
```