### PR TITLE
Return ready to be used group-specific effects design matrix when there are new groups

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### New features
 
+- The library now supports configuration variables (#95)
+- Allow evaluations on new data with new categories (#96)
+- Return ready to be used group-specific effects design matrix when there are new groups (#100)
+
 ### Maintenance and fixes
+
+- Fix typo in __str__ (#99)
 
 ### Documentation
 

--- a/formulae/config.py
+++ b/formulae/config.py
@@ -28,7 +28,7 @@ class Config:
     def __str__(self):  # pragma: no cover
         lines = []
         for field, choices in Config.FIELDS.items():
-            lines.append(f"{field}: {self[field]} (available: {choices})")
+            lines.append(f"{field}: {self[field]} (available: {list(choices)})")
         header = ["Formulae configuration"]
         header.append("-" * len(header[0]))
         return "\n".join(header + lines)

--- a/formulae/matrices.py
+++ b/formulae/matrices.py
@@ -399,7 +399,7 @@ class GroupEffectsMatrix:
 
         start = 0
         matrices_to_stack = []
-        factors_with_new_levels = set()
+        factors_with_new_levels = []
 
         for term in self.terms.values():
             term_matrix = term.eval_new_data(data)
@@ -413,8 +413,8 @@ class GroupEffectsMatrix:
             slice_w_new = get_slice_width(slice_new)
 
             # If the width of the slices differ, there's a new column, thus a new group.
-            if slice_w_original != slice_w_new:
-                factors_with_new_levels.add(term.factor.name)
+            if slice_w_original != slice_w_new and term.factor.name not in factors_with_new_levels:
+                factors_with_new_levels.append(term.factor.name)
 
             # Always store the new slice.
             # It may be affected even when there are no new groups for this group-specific term
@@ -460,7 +460,7 @@ class GroupEffectsMatrix:
             term_slice = self.slices[name]
             term_slice_width = get_slice_width(term_slice)
             levels_n = len(term.expr.levels) if has_levels else 1
-            if term_slice_width != len(groups) * levels_n: # Has extra groups
+            if term_slice_width != len(groups) * levels_n:  # Has extra groups
                 assert (
                     term_slice_width == len(groups) + levels_n
                 ), "It should only have one extra group"

--- a/formulae/matrices.py
+++ b/formulae/matrices.py
@@ -455,14 +455,18 @@ class GroupEffectsMatrix:
     def __str__(self):
         entries = []
         for name, term in self.terms.items():
+            has_levels = hasattr(term.expr, "levels") and term.expr.levels is not None
+            groups = term.groups
             term_slice = self.slices[name]
             term_slice_width = get_slice_width(term_slice)
-            groups = term.groups
-            if term_slice_width != len(groups):
-                assert term_slice_width == len(groups) + 1, "It should only have one extra group"
+            levels_n = len(term.expr.levels) if has_levels else 1
+            if term_slice_width != len(groups) * levels_n: # Has extra groups
+                assert (
+                    term_slice_width == len(groups) + levels_n
+                ), "It should only have one extra group"
                 groups = groups + ["__NEW_FACTOR_GROUP__"]
             content = [f"kind: {term.kind}", f"groups: {groups}"]
-            if hasattr(term.expr, "levels") and term.expr.levels is not None:
+            if has_levels:
                 content += [f"levels: {term.expr.levels}"]
             content += [slice_to_column(term_slice)]
             entries += [f"{name}{wrapify(spacify(multilinify(content, '')))}"]

--- a/formulae/matrices.py
+++ b/formulae/matrices.py
@@ -401,6 +401,7 @@ class GroupEffectsMatrix:
         new_instance.design_matrix = np.column_stack(
             [t.eval_new_data(data) for t in self.terms.values()]
         )
+        # TODO: Update slices if we have new groups
         new_instance.slices = self.slices
         new_instance.evaluated = True
         return new_instance

--- a/formulae/terms/terms.py
+++ b/formulae/terms/terms.py
@@ -693,11 +693,18 @@ class GroupSpecificTerm:
             The data frame where variables are taken from.
 
         Returns
-        ----------
+        -------
         Zi: np.ndarray
         """
         Xi = self.expr.eval_new_data(data)
         Ji = self.factor.eval_new_data(data)
+
+        # If a row contains ALL zeroes, then it indicates that is a new, unseen, group.
+        all_zeros = ~Ji.any(axis=1)
+        if all_zeros.any():
+            Ji = np.column_stack([Ji, np.zeros((Ji.shape[0], 1), dtype="int")])
+            Ji[all_zeros, -1] = 1
+
         if Xi.ndim == 1:
             Xi = Xi[:, np.newaxis]
         if Ji.ndim == 1:


### PR DESCRIPTION
In #96 we allowed for the creation of new design matrices when there were new groups in categoric variables. 

The use case we have in mind is to allow for predicting new groups in hierarchical models. This PR implements new functionality in which the evaluation of new data with new groups returns a group-specific effects design matrix ready to be used in operations such as dot(Z, u). 