### PR TITLE
Update is_categorical_dtype for pandas>=2.1.0

### DIFF
--- a/formulae/terms/call.py
+++ b/formulae/terms/call.py
@@ -4,12 +4,13 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from pandas.api.types import is_categorical_dtype, is_numeric_dtype, is_string_dtype
+from pandas.api.types import is_numeric_dtype, is_string_dtype
 
 from formulae.categorical import ENCODINGS, CategoricalBox, Treatment
 from formulae.config import config
 from formulae.transforms import TRANSFORMS, Proportion, Offset
 from formulae.terms.call_utils import CallVarsExtractor
+from formulae.utils import is_categorical_dtype
 
 
 class Call:

--- a/formulae/terms/variable.py
+++ b/formulae/terms/variable.py
@@ -4,10 +4,11 @@ import warnings
 import numpy as np
 import pandas as pd
 
-from pandas.api.types import is_categorical_dtype, is_numeric_dtype, is_string_dtype
+from pandas.api.types import is_numeric_dtype, is_string_dtype
 
 from formulae.config import config
 from formulae.categorical import Treatment
+from formulae.utils import is_categorical_dtype
 
 
 class Variable:

--- a/formulae/utils.py
+++ b/formulae/utils.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import numpy as np
+import pandas as pd
 
 
 def listify(obj):
@@ -38,3 +39,16 @@ def get_interaction_matrix(x, y):
         for j2 in range(y.shape[1]):
             l.append(x[:, j1] * y[:, j2])
     return np.column_stack(l)
+
+
+def is_categorical_dtype(arr_or_dtype):
+    """Check whether an array-like or dtype is of the pandas Categorical dtype."""
+    # https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#other-deprecations
+    if pd.__version__ < "2.1.0":
+        return pd.api.types.is_categorical_dtype(arr_or_dtype)
+    else:
+        if hasattr(arr_or_dtype, "dtype"):  # it's an array
+            dtype = getattr(arr_or_dtype, "dtype")
+        else:
+            dtype = arr_or_dtype
+        return isinstance(dtype, pd.CategoricalDtype)


### PR DESCRIPTION
From https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#other-deprecations:

> Deprecated `is_categorical_dtype()`, use `isinstance(obj.dtype, pd.CategoricalDtype)` instead ([GH 52527](https://github.com/pandas-dev/pandas/issues/52527))

Currently, `formulae` will surface this warning for `pandas>=2.1.0`:

```
.../formulae/terms/call.py:108: FutureWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, CategoricalDtype) instead
  elif is_string_dtype(x) or is_categorical_dtype(x) or isinstance(x, CategoricalBox):
```

(As of `pandas==2.1.4` this is a `DeprecationWarning` instead of a `FutureWarning`.)

The change in this PR should be backwards-compatible.

## How has this been tested?

In a virtual env w/ `pandas==1.3.4`, I ran `pytest`. I also checked that this snippet of code is correct.

```python
import pandas as pd
from formulae.utils import is_categorical_dtype

data = [1, 2, 3, 1, 2, 3]

data_cat = pd.Categorical(data)
assert is_categorical_dtype(data_cat)

data_num = pd.Series(data)
assert not is_categorical_dtype(data_num)
```

In a virtual env w/ `pandas==2.1.4`, I ran `pytest`. I also checked that the snippet of code above is still correct and doesn't raises a warning.