### PR TITLE
Fix pandas version check, require Python ≥ 3.8

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: python3 -m pip install --upgrade build
@@ -44,7 +44,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install twine
         run: python3 -m pip install --upgrade twine
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install twine
         run: python3 -m pip install --upgrade twine

--- a/formulae/utils.py
+++ b/formulae/utils.py
@@ -1,8 +1,9 @@
 from copy import deepcopy
 
 import numpy as np
-from packaging.version import Version
 import pandas as pd
+
+from packaging.version import Version
 
 
 def listify(obj):

--- a/formulae/utils.py
+++ b/formulae/utils.py
@@ -1,6 +1,7 @@
 from copy import deepcopy
 
 import numpy as np
+from packaging.version import Version
 import pandas as pd
 
 
@@ -44,7 +45,7 @@ def get_interaction_matrix(x, y):
 def is_categorical_dtype(arr_or_dtype):
     """Check whether an array-like or dtype is of the pandas Categorical dtype."""
     # https://pandas.pydata.org/docs/whatsnew/v2.1.0.html#other-deprecations
-    if pd.__version__ < "2.1.0":
+    if Version(pd.__version__) < Version("2.1.0"):
         return pd.api.types.is_categorical_dtype(arr_or_dtype)
     else:
         if hasattr(arr_or_dtype, "dtype"):  # it's an array

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = ["setuptools>=61.0", "setuptools_scm>=8"]
 [project]
 name = "formulae"
 description = "Formulas for mixed-effects models in Python"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {file = "LICENSE"}
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ maintainers = [{ name = "Tomás Capretto", email = "tomicapretto@gmail.com" }]
 
 dependencies = [
     "numpy>=1.16",
+    "packaging",
     "pandas>=1.0.0",
     "scipy>=1.5.4"
 ]


### PR DESCRIPTION
Hello,

This corrects the version check in #105. The current check will fail when we're (hopefully) retired and `pandas` v10 comes out:

```python
print("10.0.0" < "2.1.0")
# True
# yikes!

from packaging.version import Version
print(Version("10.0.0") < Version("2.1.0"))
# False
```

Docs for [`packaging.version.Version`](https://packaging.pypa.io/en/latest/version.html#packaging.version.Version)

The PR adds a new required dependency from PyPA: [`packaging`](https://packaging.pypa.io/en/stable/). It has no dependencies **but requires [Python ≥ 3.8](https://github.com/pypa/packaging/blob/32deafe8668a2130a3366b98154914d188f3718e/pyproject.toml#L11)**. I'm not sure if this change is too breaking b/c the test workflow only tests Python ≥ 3.9, and `bambi` requires [Python ≥ 3.10](https://github.com/bambinos/bambi/blob/a8fb6e7ce5c2805c6b7a7a30de28f08b5f7d0052/pyproject.toml#L10). And Python 3.7 reached EOL on 2023-06-27. Feel free to close the PR if this breaking change is too much breaking / you want to fix the version check a different way