### PR TITLE
Add `eval_new_data_group_index` to `GroupSpecificTerm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.X.X Unreleased
+## 0.X.X Unreleased
 
 ### New features
 
@@ -10,7 +10,27 @@
 
 ### Deprecation
 
-## v0.X.X Unreleased
+## 0.7.0
+
+### New features
+
+- Add `GroupSpecificTerm.eval_new_data_group_index()` to distinguish fitted,
+  missing, and new grouping levels when evaluating new data.
+
+### Maintenance and fixes
+
+### Documentation
+
+### Deprecation
+
+## 0.6.2
+
+### Maintenance and fixes
+
+- Update versions (#122)
+- Extend equality methods (#123)
+
+## 0.6.1
 
 ### Maintenance and fixes
 
@@ -20,7 +40,7 @@
 
 - Update README to mention formulae supports Python>=3.8 (#121)
 
-## v0.6.0
+## 0.6.0
 
 ### New features
 
@@ -37,19 +57,19 @@
 
 - Drop support for Python 3.7; Python ≥ 3.8 is now required (#110)
 
-## v0.5.4
+## 0.5.4
 
 ### Maintenance and fixes
 
 - Make sure model_description always returns a Model instance (#112)
 
-## v0.5.3
+## 0.5.3
 
 ### Maintenance and fixes
 
 - Make formulae reach transformations before outer names (#109)
 
-## v0.5.2
+## 0.5.2
 
 ### Maintenance and fixes
 
@@ -57,13 +77,13 @@
 - Add automatic versioning to the library (#106)
 - Interpret True, False, and None as Python literals (#107)
 
-## v0.5.1
+## 0.5.1
 
 ### Maintenance and fixes
 
 - Fix bug when intercept is inserted after categorical variable (#102)
 
-## v0.5.0
+## 0.5.0
 
 ### New features
 
@@ -79,7 +99,7 @@
 
 ### Deprecation
 
-## v0.4.0
+## 0.4.0
 
 ### New features
 

--- a/formulae/terms/terms.py
+++ b/formulae/terms/terms.py
@@ -7,7 +7,9 @@ from functools import reduce
 from itertools import combinations, product
 
 import numpy as np
+import pandas as pd
 
+from formulae.categorical import CategoricalBox
 from formulae.utils import get_interaction_matrix, row_khatri_rao_sparse
 from formulae.contrasts import pick_contrasts
 
@@ -681,6 +683,70 @@ class GroupSpecificTerm:
             Ji = Ji[:, np.newaxis]
 
         self.data = row_khatri_rao_sparse(Xi, Ji.argmax(1), Ji.shape[1])
+
+    def eval_new_data_group_index(self, data):
+        """Evaluate the grouping factor as indices for new data.
+
+        Unlike :meth:`eval_new_data`, this method preserves the distinction between
+        missing values and unseen, non-missing levels. Existing factor columns are
+        represented by their fitted index, missing values by ``-1``, and unseen
+        levels by consecutive indices after the fitted columns.
+
+        Parameters
+        ----------
+        data : pandas.DataFrame
+            The data frame where factor values are taken from.
+
+        Returns
+        -------
+        index : numpy.ndarray
+            One-dimensional ``int64`` array. Existing groups use indices in
+            ``0..G-1``, missing groups use ``-1``, and new groups use ``G..``.
+        new_groups : tuple
+            New, non-missing levels in first-occurrence order.
+            Interaction levels are represented as tuples of their component values.
+        """
+        values = []
+        codes = []
+        missing = []
+
+        components_n = len(self.factor.components)
+        obs_n = len(data)
+        index = np.full(obs_n, -1, dtype=np.int64)
+
+        for component in self.factor.components:
+            if isinstance(component, Variable):
+                value = data[component.name]
+            else:
+                assert isinstance(component, Call)
+                value = component.call.eval(data, component.env)
+                if isinstance(value, CategoricalBox):
+                    value = value.data
+
+            values.append(np.asarray(value))
+            codes.append(pd.Categorical(value, categories=component.levels).codes)
+            missing.append(np.asarray(pd.isna(value), dtype=bool))
+
+        missing = np.logical_or.reduce(missing)  # missing[0] | missing[1] | ...
+        known = np.logical_and.reduce([code >= 0 for code in codes])
+        dimensions = tuple(len(component.levels) for component in self.factor.components)
+        index[known] = np.ravel_multi_index(tuple(code[known] for code in codes), dimensions)
+        n_fitted_groups = int(np.prod(dimensions))
+
+        new_groups = []
+        new_group_indices = {}
+        for row in np.flatnonzero(~known & ~missing):
+            group = tuple(value[row] for value in values)
+            if group not in new_group_indices:
+                new_group_indices[group] = n_fitted_groups + len(new_groups)
+                new_groups.append(group)
+
+            index[row] = new_group_indices[group]
+
+        if components_n == 1:
+            new_groups = [group[0] for group in new_groups]
+
+        return index, tuple(new_groups)
 
     def eval_new_data(self, data):
         """Evaluates the term with new data.

--- a/tests/test_eval_new_data.py
+++ b/tests/test_eval_new_data.py
@@ -399,3 +399,44 @@ def test_new_group_specific_groups():
 
     # Reset config
     config.EVAL_UNSEEN_CATEGORIES = "error"
+
+
+def test_group_factor_evaluates_new_data_indices():
+    train = pd.DataFrame({"y": [0, 1, 2, 3], "g": ["a", "a", "b", "b"]})
+    term = design_matrices("y ~ (1 | g)", train).group.terms["1|g"]
+    new_data = pd.DataFrame({"g": ["b", None, "new-1", "new-2", "new-1", "a", np.nan]})
+
+    index, new_groups = term.eval_new_data_group_index(new_data)
+
+    assert index.dtype == np.int64
+    assert np.array_equal(index, np.array([1, -1, 2, 3, 2, 0, -1], dtype=np.int64))
+    assert new_groups == ("new-1", "new-2")
+
+
+def test_group_interaction_evaluates_new_data_indices_in_factor_column_order():
+    # The fitted data only contains the diagonal combinations.
+    # Formulae nevertheless creates a full Cartesian product of factor columns.
+    train = pd.DataFrame({"y": [0, 1], "left": ["a", "b"], "right": ["x", "y"]})
+    term = design_matrices("y ~ (1 | left:right)", train).group.terms["1|left:right"]
+    new_data = pd.DataFrame(
+        {
+            "left": ["a", "b", "new", "new", "new", "a", None],
+            "right": ["y", "x", "x", "x", "y", None, "new"],
+        }
+    )
+
+    index, new_groups = term.eval_new_data_group_index(new_data)
+
+    assert term.factor.data.shape[1] == 4
+    assert np.array_equal(index, np.array([1, 2, 4, 4, 5, -1, -1], dtype=np.int64))
+    assert new_groups == (("new", "x"), ("new", "y"))
+
+
+def test_group_factor_call_evaluates_new_data_indices():
+    train = pd.DataFrame({"y": [0, 1], "g": ["a", "b"]})
+    term = design_matrices("y ~ (1 | C(g))", train).group.terms["1|C(g)"]
+
+    index, new_groups = term.eval_new_data_group_index(pd.DataFrame({"g": ["b", "new", None]}))
+
+    assert np.array_equal(index, np.array([1, 2, -1], dtype=np.int64))
+    assert new_groups == ("new",)


### PR DESCRIPTION
This method allows us to distinguish fitted, missing, and new grouping levels when evaluating new data and it is useful for out-of-group prediction in hierarchical models.